### PR TITLE
add rudimentary zio-stream support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 inThisBuild(Seq(
   version := "0.1.0-SNAPSHOT",
 
@@ -101,6 +102,20 @@ lazy val rx = project
     )
   )
 
+lazy val zio = project
+  .enablePlugins(ScalaJSPlugin)
+  .dependsOn(colibri)
+  .in(file("zio"))
+  .settings(commonSettings, jsSettings)
+  .settings(
+    name := "colibri-zio",
+
+    libraryDependencies ++= Seq(
+      "dev.zio" %%% "zio" % "1.0.10",
+      "dev.zio" %%% "zio-streams" % "1.0.10"
+    )
+  )
+
 lazy val root = project
   .in(file("."))
   .settings(
@@ -108,4 +123,4 @@ lazy val root = project
 
     skip in publish := true,
   )
-  .aggregate(colibri, monix, rx, router)
+  .aggregate(colibri, monix, rx, zio, router)

--- a/build.sbt
+++ b/build.sbt
@@ -111,8 +111,8 @@ lazy val zio = project
     name := "colibri-zio",
 
     libraryDependencies ++= Seq(
-      "dev.zio" %%% "zio" % "1.0.10",
-      "dev.zio" %%% "zio-streams" % "1.0.10"
+      "dev.zio" %%% "zio" % "1.0.11",
+      "dev.zio" %%% "zio-streams" % "1.0.11"
     )
   )
 

--- a/zio/src/main/scala/colibri/ext/zio/ops.scala
+++ b/zio/src/main/scala/colibri/ext/zio/ops.scala
@@ -1,0 +1,20 @@
+package colibri.ext.zio
+
+import _root_.zio.stream.{Stream, UStream, ZSink, ZStream}
+import _root_.zio.{Fiber, Chunk, Ref, Runtime, UIO, ZEnv, ZIO, URIO, IO, Task}
+import colibri._
+
+object ops {
+  implicit class RichZStreamCompanion(val unused: ZStream.type) {
+    def fromSink[R, E, A](fn: ZSink[R, E, A, A, Unit] => IO[E, Unit]): ZStream[R, E, A] = ZStream.effectAsyncM { emit =>
+      fn(
+        ZSink.foreach[Any, E, A](value => Task.fromFuture(_ => emit.single(value)).ignore)
+          .foldM(error => ZSink.fromEffect(Task.fromFuture(_ => emit.fail(error)).ignore), _ => ZSink.drain)
+      )
+    }
+  }
+
+  implicit class RichSink[-R, +E, -A, +L, +Z](val stream: ZSink[R, E, A, L, Z]) extends AnyVal {
+    def redirect
+  }
+}

--- a/zio/src/main/scala/colibri/ext/zio/package.scala
+++ b/zio/src/main/scala/colibri/ext/zio/package.scala
@@ -1,0 +1,57 @@
+package colibri.ext
+
+import _root_.zio.stream.{Stream, UStream, ZSink, ZStream}
+import _root_.zio.{Chunk, Ref, Runtime, UIO, ZEnv, ZIO, URIO}
+import colibri._
+
+package object zio {
+  type TSink[A] = ZSink[Any, Throwable, A, A, Unit]
+
+  // Sink
+
+  implicit def zioSinkSink(implicit runtime: Runtime[ZEnv]): Sink[TSink] = new Sink[TSink] {
+    def onNext[A](sink: TSink[A])(value: A): Unit =
+      runtime.unsafeRun(UStream(value).run(sink))
+
+    def onError[A](sink: TSink[A])(error: Throwable): Unit =
+      runtime.unsafeRun(ZStream.fail(error).run(sink))
+  }
+
+  implicit object zioSinkLiftSink extends LiftSink[TSink] {
+    def lift[G[_]: Sink, A](sink: G[A]): TSink[A] = ZSink
+      .foreach[Any, Throwable, A](elem => UIO(Sink[G].onNext(sink)(elem)))
+      .foldM(error => ZSink.fromEffect(UIO(Sink[G].onError(sink)(error))), _ => ZSink.drain)
+  }
+
+  // Source
+
+  type TStream[A] = ZStream[Any, Throwable, A]
+
+  implicit def zioStreamSource(implicit runtime: Runtime[ZEnv]): Source[TStream] = new Source[TStream] {
+    def subscribe[G[_] : Sink, A](source: TStream[A])(sink: G[_ >: A]): Cancelable =
+      runtime.unsafeRun(for {
+        running <- Ref.make[Boolean](false)
+        valueFn = Sink[G].onNext(sink)_
+        errorFn = Sink[G].onError(sink)_
+        consumer = ZSink.foreachWhile[Any, Throwable, A](
+          value => UIO(valueFn(value)) *> running.get
+        ).foldM[Any, Throwable, A, A, Unit](error => ZSink.fromEffect(UIO(errorFn(error))), _ => ZSink.drain)
+        _ <- source.run(consumer)
+      } yield Cancelable(() => runtime.unsafeRun(running.set(false))))
+  }
+
+  implicit object zioStreamLiftSource extends LiftSource[TStream] {
+    override def lift[G[_] : Source, A](source: G[A]): TStream[A] = Stream.effectAsyncInterrupt { register =>
+      val cancelable = Source[G].subscribe(source)(new Observer[A] {
+        override def onNext(value: A): Unit = {
+          register(UIO(Chunk(value))); ()
+        }
+
+        override def onError(error: Throwable): Unit = {
+          register(ZIO.fail(Some(error))); ()
+        }
+      })
+      Left(URIO(cancelable.cancel()))
+    }
+  }
+}

--- a/zio/src/main/scala/colibri/ext/zio/package.scala
+++ b/zio/src/main/scala/colibri/ext/zio/package.scala
@@ -1,7 +1,7 @@
 package colibri.ext
 
 import _root_.zio.stream.{Stream, UStream, ZSink, ZStream}
-import _root_.zio.{Fiber, Chunk, Ref, Runtime, UIO, ZEnv, ZIO, URIO}
+import _root_.zio.{Ref, Runtime, UIO, ZEnv, URIO}
 import colibri._
 
 package object zio {

--- a/zio/src/test/scala/colibri/ZIOOpsSpec.scala
+++ b/zio/src/test/scala/colibri/ZIOOpsSpec.scala
@@ -1,0 +1,13 @@
+package colibri
+
+import colibri.ext.zio._
+// import colibri.ext.zio.ops._
+
+import zio._
+import zio.stream._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AsyncFlatSpec
+
+class ZIOOpsSpec extends AsyncFlatSpec with Matchers {
+
+}


### PR DESCRIPTION
This is still a work in progress and is missing tests and some implementations. Feedback welcome.  
That being said, zio streams don't translate well to a reactive-streams style api. Especially ZSink is kinda dodgy.  
Zio streams are completely functionally pure, while reactive streams rely on impure behavior here and there. Especially when subscribing, cancelling and in subjects.  
Speaking of which, I have no Idea how I should implement subjects because ZStream and ZSink both are abstract classes and not traits, so they cannot be combined.  

This approach currently includes the following type aliases:  
```scala
type TSink[A]   = ZSink[Any, Throwable, A, A, Unit]
type TStream[A] = ZStream[Any, Throwable, A]
```
These are necessary to pass the type to the type parameter of `Sink` and `Source` respectively.  
I thought this would look a little nicer than using type lambdas.  
The `T` in `TSink` and `TStream` stands for `Task` since their static type parameters are identical to zio's `type Task[A] = ZIO[Any, Throwable, A]`