### PR TITLE
Increase purity by introducing F[_] to Sink, Source and Cancelable

### DIFF
--- a/colibri/src/main/scala/colibri/CanCancel.scala
+++ b/colibri/src/main/scala/colibri/CanCancel.scala
@@ -1,7 +1,9 @@
 package colibri
 
+import cats.effect.Sync
+
 trait CanCancel[-T] {
-  def cancel(cancelable: T): Unit
+  def cancel[F[_] : Sync](cancelable: T): F[Unit]
 }
 object CanCancel {
   @inline def apply[T](implicit cancel: CanCancel[T]): CanCancel[T] = cancel

--- a/colibri/src/main/scala/colibri/Observer.scala
+++ b/colibri/src/main/scala/colibri/Observer.scala
@@ -1,19 +1,22 @@
 package colibri
 
+import cats.syntax.all._
+import cats.implicits._
 import cats.{MonoidK, Contravariant}
+import cats.effect.Sync
 import colibri.helpers._
 
 import scala.util.control.NonFatal
 
 trait Observer[-A] {
-  def onNext(value: A): Unit
-  def onError(error: Throwable): Unit
+  def onNext[F[_] : Sync](value: A): F[Unit]
+  def onError[F[_] : Sync](error: Throwable): F[Unit]
 }
 object Observer {
 
   object Empty extends Observer[Any] {
-    @inline def onNext(value: Any): Unit = ()
-    @inline def onError(error: Throwable): Unit = UnhandledErrorReporter.errorSubject.onNext(error)
+    @inline def onNext[F[_] : Sync](value: Any): F[Unit] = ().pure[F]
+    @inline def onError[F[_] : Sync](error: Throwable): F[Unit] = UnhandledErrorReporter.errorSubject.onNext(error)
   }
 
   @inline def empty = Empty
@@ -30,70 +33,64 @@ object Observer {
   def lift[G[_] : Sink, A](sink: G[A]): Observer[A] =  sink match {
     case sink: Observer[A@unchecked] => sink
     case _ => new Observer[A] {
-      def onNext(value: A): Unit = Sink[G].onNext(sink)(value)
-      def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+      def onNext[F[_] : Sync](value: A): F[Unit] = Sink[G].onNext(sink)(value)
+      def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
     }
   }
 
   @inline def unsafeCreate[A](consume: A => Unit, failure: Throwable => Unit = UnhandledErrorReporter.errorSubject.onNext): Observer[A] = new Observer[A] {
-    def onNext(value: A): Unit = consume(value)
-    def onError(error: Throwable): Unit = failure(error)
+    def onNext[F[_] : Sync](value: A): F[Unit] = consume(value).pure[F]
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = failure(error).pure[F]
   }
 
   def create[A](consume: A => Unit, failure: Throwable => Unit = UnhandledErrorReporter.errorSubject.onNext): Observer[A] = new Observer[A] {
-    def onNext(value: A): Unit = recovered(consume(value), onError)
-    def onError(error: Throwable): Unit = failure(error)
+    def onNext[F[_] : Sync](value: A): F[Unit] = recoveredF(consume(value).pure[F], onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = failure(error).pure[F]
   }
 
   @inline def combine[G[_] : Sink, A](sinks: G[A]*): Observer[A] = combineSeq(sinks)
 
   def combineSeq[G[_] : Sink, A](sinks: Seq[G[A]]): Observer[A] = new Observer[A] {
-    def onNext(value: A): Unit = sinks.foreach(Sink[G].onNext(_)(value))
-    def onError(error: Throwable): Unit = sinks.foreach(Sink[G].onError(_)(error))
+    def onNext[F[_] : Sync](value: A): F[Unit] = sinks.toList.traverse_(Sink[G].onNext(_)(value))
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = sinks.toList.traverse_(Sink[G].onError(_)(error))
   }
 
   def combineVaried[GA[_] : Sink, GB[_] : Sink, A](sinkA: GA[A], sinkB: GB[A]): Observer[A] = new Observer[A] {
-    def onNext(value: A): Unit = {
-      Sink[GA].onNext(sinkA)(value)
-      Sink[GB].onNext(sinkB)(value)
-    }
-    def onError(error: Throwable): Unit = {
-      Sink[GA].onError(sinkA)(error)
-      Sink[GB].onError(sinkB)(error)
-    }
+    def onNext[F[_] : Sync](value: A): F[Unit] = Sink[GA].onNext(sinkA)(value) *> Sink[GB].onNext(sinkB)(value)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[GA].onError(sinkA)(error) *> Sink[GB].onError(sinkB)(error)
   }
 
   def contramap[G[_] : Sink, A, B](sink: G[_ >: A])(f: B => A): Observer[B] = new Observer[B] {
-    def onNext(value: B): Unit = recovered(Sink[G].onNext(sink)(f(value)), onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF(Sink[G].onNext(sink)(f(value)), onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contramapEither[G[_] : Sink, A, B](sink: G[_ >: A])(f: B => Either[Throwable, A]): Observer[B] = new Observer[B] {
-    def onNext(value: B): Unit = recovered(f(value) match {
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF(f(value) match {
       case Right(value) => Sink[G].onNext(sink)(value)
       case Left(error) => Sink[G].onError(sink)(error)
     }, onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contramapFilter[G[_] : Sink, A, B](sink: G[_ >: A])(f: B => Option[A]): Observer[B] = new Observer[B] {
-    def onNext(value: B): Unit = recovered(f(value).foreach(Sink[G].onNext(sink)), onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF(f(value).traverse_(Sink[G].onNext(sink)), onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contracollect[G[_] : Sink, A, B](sink: G[_ >: A])(f: PartialFunction[B, A]): Observer[B] = new Observer[B] {
-    def onNext(value: B): Unit = recovered({ f.runWith(Sink[G].onNext(sink))(value); () }, onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF(f.lift(value).traverse_(Sink[G].onNext(sink)), onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contrafilter[G[_] : Sink, A](sink: G[_ >: A])(f: A => Boolean): Observer[A] = new Observer[A] {
-    def onNext(value: A): Unit = recovered(if (f(value)) Sink[G].onNext(sink)(value), onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onNext[F[_] : Sync](value: A): F[Unit] = recoveredF(Sink[G].onNext(sink)(value).whenA(f(value)), onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contramapIterable[G[_] : Sink, A, B](sink: G[_ >: A])(f: B => Iterable[A]): Observer[B] = new Observer[B] {
-    def onNext(value: B): Unit = recovered(f(value).foreach(Sink[G].onNext(sink)(_)), onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF(f(value).toList.traverse_(Sink[G].onNext(sink)), onError)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def contraflattenIterable[G[_] : Sink, A, B](sink: G[_ >: A]): Observer[Iterable[A]] = contramapIterable(sink)(identity)
@@ -101,12 +98,12 @@ object Observer {
   //TODO return effect
   def contrascan[G[_] : Sink, A, B](sink: G[_ >: A])(seed: A)(f: (A, B) => A): Observer[B] = new Observer[B] {
     private var state = seed
-    def onNext(value: B): Unit = recovered({
+    def onNext[F[_] : Sync](value: B): F[Unit] = recoveredF({
       val result = f(state, value)
       state = result
       Sink[G].onNext(sink)(result)
     }, onError)
-    def onError(error: Throwable): Unit = Sink[G].onError(sink)(error)
+    def onError[F[_] : Sync](error: Throwable): F[Unit] = Sink[G].onError(sink)(error)
   }
 
   def doOnNext[G[_] : Sink, A](sink: G[_ >: A])(f: A => Unit): Observer[A] = new Observer[A] {
@@ -159,4 +156,5 @@ object Observer {
   }
 
   private def recovered(action: => Unit, onError: Throwable => Unit): Unit = try action catch { case NonFatal(t) => onError(t) }
+  private def recoveredF[F[_] : Sync](action: => F[Unit], onError: Throwable => F[Unit]): F[Unit] = try action catch { case NonFatal(t) => onError(t) }
 }

--- a/colibri/src/main/scala/colibri/Sink.scala
+++ b/colibri/src/main/scala/colibri/Sink.scala
@@ -1,8 +1,10 @@
 package colibri
 
+import cats.effect.Sync
+
 trait Sink[-G[_]] {
-  def onNext[A](sink: G[A])(value: A): Unit
-  def onError[A](sink: G[A])(error: Throwable): Unit
+  def onNext[F[_] : Sync, A](sink: G[A])(value: A): F[Unit]
+  def onError[F[_] : Sync, A](sink: G[A])(error: Throwable): F[Unit]
 }
 object Sink {
   @inline def apply[G[_]](implicit sink: Sink[G]): Sink[G] = sink

--- a/colibri/src/main/scala/colibri/Source.scala
+++ b/colibri/src/main/scala/colibri/Source.scala
@@ -1,7 +1,9 @@
 package colibri
 
+import cats.effect.Sync
+
 trait Source[-H[_]] {
-  def subscribe[HH[_] : Sink, A](source: H[A])(sink: HH[_ >: A]): Cancelable
+  def subscribe[F[_] : Sync, HH[_] : Sink, A](source: H[A])(sink: HH[_ >: A]): F[Cancelable]
 }
 object Source {
   @inline def apply[H[_]](implicit source: Source[H]): Source[H] = source


### PR DESCRIPTION
This pull request aims to add polymorphic `F[_]` effect types to the `onNext`, `onError` and `subscribe` functions found in `Sink` and `Souce`. This is to make integrating libraries like *zio_stream* or *fs2* easier and most importantly safer / purer.  

The pull request is based on #122 since it makes it a lot easier to implement `F[_]` in many places.

This is still a work in progress, at the moment this PR mostly serves to keep people informed about the progress on this and to encourage discussion.  

---  

This change was previously being tracked in #123 but unfortunately the branch got deleted, which resulted in closing the PR.  
I wanted to rename the branch while the PR was open, which github should support when done from inside github, but that seems to have failed.