### PR TITLE
add isEmpty to Cancelable

### DIFF
--- a/colibri/src/main/scala/colibri/Connectable.scala
+++ b/colibri/src/main/scala/colibri/Connectable.scala
@@ -19,6 +19,7 @@ object Connectable                                                              
     }
     def hot: Observable.Hot[A]  = new Observable[A] with Cancelable {
       private val cancelable                             = source.connect()
+      def isEmpty()                                      = cancelable.isEmpty()
       def unsafeCancel()                                 = cancelable.unsafeCancel()
       def unsafeSubscribe(sink: Observer[A]): Cancelable = source.value.unsafeSubscribe(sink)
     }
@@ -31,6 +32,7 @@ object Connectable                                                              
     }
     def hot: Observable.HotValue[A]   = new Observable.Value[A] with Cancelable {
       private val cancelable                             = source.connect()
+      def isEmpty()                                      = cancelable.isEmpty()
       def unsafeCancel()                                 = cancelable.unsafeCancel()
       def now()                                          = source.value.now()
       def unsafeSubscribe(sink: Observer[A]): Cancelable = source.value.unsafeSubscribe(sink)
@@ -44,6 +46,7 @@ object Connectable                                                              
     }
     def hot: Observable.HotMaybeValue[A]   = new Observable.MaybeValue[A] with Cancelable {
       private val cancelable                             = source.connect()
+      def isEmpty()                                      = cancelable.isEmpty()
       def unsafeCancel()                                 = cancelable.unsafeCancel()
       def now()                                          = source.value.now()
       def unsafeSubscribe(sink: Observer[A]): Cancelable = source.value.unsafeSubscribe(sink)

--- a/colibri/src/main/scala/colibri/effect/RunEffectExecution.scala
+++ b/colibri/src/main/scala/colibri/effect/RunEffectExecution.scala
@@ -22,7 +22,7 @@ private[colibri] object RunEffectExecution {
 
     future.onComplete(result => action(result.toEither))(parasitic)
 
-    Cancelable { () =>
+    Cancelable.withIsEmpty(isCancel) { () =>
       isCancel = true
       cancelRun()
       ()


### PR DESCRIPTION
This is kind of like a poor man's completion implementation.

A cancelable, therefore every subscription, exposes `isEmpty()`.
Checking isEmpty returns true if this observable will not trigger anymore within this subscription, and there is no need to call cancel.

Different than real completion with a completion event, here you cannot implement concatenation of observable generally.
But a user can check whether this subscription still needs to be taken care of and whether it can yield new values.
