### PR TITLE
Fix Rx#collect and Rx#filter

### DIFF
--- a/reactive/src/test/scala/colibri/RxSpec.scala
+++ b/reactive/src/test/scala/colibri/RxSpec.scala
@@ -452,4 +452,21 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
 
   }.unsafeRunSync()
 
+  it should "collect initial none" in Owned {
+    val variable        = Var[Option[Int]](None)
+    val collected       = variable.collect { case Some(x) => x }(0)
+    var collectedStates = Vector.empty[Int]
+
+    collected.foreach(collectedStates :+= _)
+
+    collectedStates shouldBe Vector(0)
+
+    variable.set(None)
+    collectedStates shouldBe Vector(0)
+
+    variable.set(Some(17))
+    collectedStates shouldBe Vector(0, 17)
+
+  }.unsafeRunSync()
+
 }

--- a/reactive/src/test/scala/colibri/RxSpec.scala
+++ b/reactive/src/test/scala/colibri/RxSpec.scala
@@ -434,4 +434,22 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
     rx.now() shouldBe "false:false"
     liveCounter shouldBe 5
   }.unsafeRunSync()
+
+  it should "collect" in Owned {
+    val variable        = Var[Option[Int]](Some(1))
+    val collected       = variable.collect { case Some(x) => x }(0)
+    var collectedStates = Vector.empty[Int]
+
+    collected.foreach(collectedStates :+= _)
+
+    collectedStates shouldBe Vector(1)
+
+    variable.set(None)
+    collectedStates shouldBe Vector(1)
+
+    variable.set(Some(17))
+    collectedStates shouldBe Vector(1, 17)
+
+  }.unsafeRunSync()
+
 }


### PR DESCRIPTION
I added a test case which I think should work:

```scala
    val variable        = Var[Option[Int]](Some(1))
    val collected       = variable.collect { case Some(x) => x }(0)
    var collectedStates = Vector.empty[Int]

    collected.foreach(collectedStates :+= _)

    collectedStates shouldBe Vector(1) // FAILS HERE, because it's `Vector(0)`

    variable.set(None)
    collectedStates shouldBe Vector(1)

    variable.set(Some(17))
    collectedStates shouldBe Vector(1, 17)
```