### PR TITLE
Attempt to implement distinctness on sequences outer RX

### DIFF
--- a/reactive/src/main/scala/colibri/reactive/Reactive.scala
+++ b/reactive/src/main/scala/colibri/reactive/Reactive.scala
@@ -170,7 +170,6 @@ object Var {
                 {
                   case (Some(prev @ _), Some(next)) =>
                     cache.get.set(next)
-                    println(("next: ", next, cache.toString))
 
                   case (Some(prev @ _), None) =>
                     cache = None

--- a/reactive/src/test/scala/colibri/RxSpec.scala
+++ b/reactive/src/test/scala/colibri/RxSpec.scala
@@ -530,12 +530,9 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
     }
 
     {
-      println("test starting")
-
       // inner.set on seed value
       val variable                       = Var[Option[Int]](Some(1))
       val sequence: Rx[Option[Var[Int]]] = variable.sequence
-      println("set initial")
 
       var outerTriggered = 0
       var innerTriggered = 0
@@ -548,9 +545,7 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
       innerTriggered shouldBe 1
       val varRefA = sequence.now().get
 
-      println("update outer")
       variable.set(Some(2))
-      println("update done")
       variable.now() shouldBe Some(2)
       sequence.now().map(_.now()) shouldBe Some(2)
       outerTriggered shouldBe 1

--- a/reactive/src/test/scala/colibri/RxSpec.scala
+++ b/reactive/src/test/scala/colibri/RxSpec.scala
@@ -540,7 +540,7 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
       var outerTriggered = 0
       var innerTriggered = 0
       sequence.foreach(_ => outerTriggered += 1)
-      sequence.now().foreach(_ => innerTriggered += 1)
+      sequence.now().foreach(_.foreach(_ => innerTriggered += 1))
 
       variable.now() shouldBe Some(1)
       sequence.now().map(_.now()) shouldBe Some(1)

--- a/reactive/src/test/scala/colibri/RxSpec.scala
+++ b/reactive/src/test/scala/colibri/RxSpec.scala
@@ -528,5 +528,35 @@ class ReactiveSpec extends AsyncFlatSpec with Matchers {
       variable.set(None)
       sequence.now().map(_.now()) shouldBe None
     }
+
+    {
+      println("test starting")
+
+      // inner.set on seed value
+      val variable                       = Var[Option[Int]](Some(1))
+      val sequence: Rx[Option[Var[Int]]] = variable.sequence
+      println("set initial")
+
+      var outerTriggered = 0
+      var innerTriggered = 0
+      sequence.foreach(_ => outerTriggered += 1)
+      sequence.now().foreach(_ => innerTriggered += 1)
+
+      variable.now() shouldBe Some(1)
+      sequence.now().map(_.now()) shouldBe Some(1)
+      outerTriggered shouldBe 1
+      innerTriggered shouldBe 1
+      val varRefA = sequence.now().get
+
+      println("update outer")
+      variable.set(Some(2))
+      println("update done")
+      variable.now() shouldBe Some(2)
+      sequence.now().map(_.now()) shouldBe Some(2)
+      outerTriggered shouldBe 1
+      innerTriggered shouldBe 2
+      val varRefB = sequence.now().get
+      assert(varRefA eq varRefB)
+    }
   }.unsafeRunSync()
 }


### PR DESCRIPTION
This PR attempts to prevent the newly created outer RX on `.sequence` to update when only the content of the inner Var is supposed to change.